### PR TITLE
fix: add has trap to client proxy for in operator support

### DIFF
--- a/src/contest.test.ts
+++ b/src/contest.test.ts
@@ -140,4 +140,16 @@ describe('createContext', () => {
     const [ctx, prisma] = await makeContext('transactionStarted');
     expect(prisma.meta).toEqual((ctx.client as PrismaClientStub).meta);
   });
+
+  it('has trap returns true for properties on the transaction client', async () => {
+    const [ctx] = await makeContext('transactionStarted');
+    expect('$connect' in ctx.client).toBe(true);
+    expect('meta' in ctx.client).toBe(true);
+    expect('nonExistentProp' in ctx.client).toBe(false);
+  });
+
+  it('has trap returns false when no transaction is active', async () => {
+    const [ctx] = await makeContext('transactionPending');
+    expect('$connect' in ctx.client).toBe(false);
+  });
 });

--- a/src/context.ts
+++ b/src/context.ts
@@ -86,6 +86,10 @@ export function createContext(options: PrismaPostgresEnvironmentOptions) {
    * error message.
    */
   const client: PrismaClientLike = new Proxy({} as PrismaClientLike, {
+    has: (_target, name) => {
+      if (!transactionClient) return false;
+      return name in transactionClient;
+    },
     get: (_target, name: keyof PrismaClientLike | symbol) => {
       if (!transactionClient) {
         throw new Error(


### PR DESCRIPTION
## Summary

- The client `Proxy` was missing a `has` trap, so the `in` operator (e.g. `"chapter" in client`) always returned `false` — this broke libraries like Pothos Prisma plugin that [rely on `in` to check for delegate existence](https://github.com/hayes/pothos/blob/main/packages/plugin-prisma/src/util/datamodel.ts#L101)
- Added a `has` trap that delegates to `transactionClient` when active, or returns `false` when no transaction is active

## Test plan

- [x] `has` trap returns `true` for existing properties and `false` for non-existent properties during active transaction
- [x] `has` trap returns `false` when no transaction is active
- [x] All existing tests pass, 100% coverage maintained

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added test cases validating proxy trap behavior for existing and non-existent properties, and proper handling when no active transaction is present.

* **Improvements**
  * Enhanced proxy property existence checking to correctly handle scenarios when no active transaction is present.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->