### PR TITLE
fix: use dynamic import() to load Prisma client (fixes #22)

### DIFF
--- a/src/contest.test.ts
+++ b/src/contest.test.ts
@@ -19,8 +19,8 @@ const makeContext = async (
     | 'transactionPending'
     | 'transactionStarted'
     | 'transactionEnded' = 'transactionPending',
-): Promise<[ReturnType<typeof createContext>, PrismaClientStub]> => {
-  const context = createContext({
+): Promise<[Awaited<ReturnType<typeof createContext>>, PrismaClientStub]> => {
+  const context = await createContext({
     clientPath: '../test/prisma-client-stub.js',
     databaseUrl: 'postgres://fake',
     log: ['query'],

--- a/src/contest.test.ts
+++ b/src/contest.test.ts
@@ -1,3 +1,5 @@
+import { resolve } from 'node:path';
+import { pathToFileURL } from 'node:url';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import {
   type PrismaClient as PrismaClientStub,
@@ -21,7 +23,7 @@ const makeContext = async (
     | 'transactionEnded' = 'transactionPending',
 ): Promise<[Awaited<ReturnType<typeof createContext>>, PrismaClientStub]> => {
   const context = await createContext({
-    clientPath: '../test/prisma-client-stub.js',
+    clientPath: './test/prisma-client-stub.js',
     databaseUrl: 'postgres://fake',
     log: ['query'],
     transactionOptions: { timeout: 123 },
@@ -45,6 +47,24 @@ describe('createContext', () => {
   it('creates PrismaClient with PrismaPg adapter', async () => {
     vi.stubEnv('DATABASE_URL', 'postgres://fake');
     const [ctx] = await makeContext();
+
+    expect(PrismaPgMock).toHaveBeenCalledWith({
+      connectionString: 'postgres://fake',
+    });
+
+    await ctx.teardown();
+  });
+
+  it('accepts an absolute file:// URL as clientPath', async () => {
+    vi.stubEnv('DATABASE_URL', 'postgres://fake');
+    const fileUrl = pathToFileURL(resolve('./test/prisma-client-stub.js')).href;
+    const ctx = await createContext({
+      clientPath: fileUrl,
+      databaseUrl: 'postgres://fake',
+      log: ['query'],
+      transactionOptions: { timeout: 123 },
+    });
+    await ctx.setup();
 
     expect(PrismaPgMock).toHaveBeenCalledWith({
       connectionString: 'postgres://fake',

--- a/src/context.ts
+++ b/src/context.ts
@@ -1,3 +1,5 @@
+import { isAbsolute, resolve } from 'node:path';
+import { pathToFileURL } from 'node:url';
 import { PrismaPg } from '@prisma/adapter-pg';
 import type {
   PrismaClientLike,
@@ -28,7 +30,17 @@ export async function createContext(options: PrismaPostgresEnvironmentOptions) {
    */
   let internalEndTestTransaction: (() => void) | null = null;
 
-  const { PrismaClient } = await import(options.clientPath);
+  // Normalize clientPath so relative/absolute filesystem paths resolve against
+  // the consuming project's CWD instead of this module's location. Leave bare
+  // module specifiers (e.g. '@prisma/client') and existing file:// URLs
+  // untouched so ESM resolution handles them as-is.
+  const isPathLike =
+    options.clientPath.startsWith('.') || isAbsolute(options.clientPath);
+  const clientImportPath = isPathLike
+    ? pathToFileURL(resolve(options.clientPath)).href
+    : options.clientPath;
+
+  const { PrismaClient } = await import(clientImportPath);
   const originalClient: PrismaClientLike = new PrismaClient({
     adapter: new PrismaPg({ connectionString: process.env.DATABASE_URL }),
     log: options.log,

--- a/src/context.ts
+++ b/src/context.ts
@@ -1,11 +1,8 @@
-import { createRequire } from 'node:module';
 import { PrismaPg } from '@prisma/adapter-pg';
 import type {
   PrismaClientLike,
   PrismaPostgresEnvironmentOptions,
 } from './dts/index.js';
-
-const require = createRequire(import.meta.url);
 
 /**
  * Creates the test context used by the `prisma-postgres` Vitest environment.
@@ -14,7 +11,7 @@ const require = createRequire(import.meta.url);
  * @returns The test context object used by both the Vitest environment and the
  * user's Prisma client mock.
  */
-export function createContext(options: PrismaPostgresEnvironmentOptions) {
+export async function createContext(options: PrismaPostgresEnvironmentOptions) {
   let savePointCounter = 0;
 
   /**
@@ -31,7 +28,7 @@ export function createContext(options: PrismaPostgresEnvironmentOptions) {
    */
   let internalEndTestTransaction: (() => void) | null = null;
 
-  const { PrismaClient } = require(options.clientPath);
+  const { PrismaClient } = await import(options.clientPath);
   const originalClient: PrismaClientLike = new PrismaClient({
     adapter: new PrismaPg({ connectionString: process.env.DATABASE_URL }),
     log: options.log,

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -24,7 +24,7 @@ import environment from '../src/index.js';
 describe('prisma-postgres environment', () => {
   const global: any = {};
   const options = {
-    clientPath: '../test/prisma-client-stub.js',
+    clientPath: './test/prisma-client-stub.js',
   };
 
   beforeEach(() => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -17,7 +17,7 @@ const environment: Environment = {
       throw new Error('no DATABASE_URL defined!');
     }
 
-    const ctx = createContext(options);
+    const ctx = await createContext(options);
     await ctx.setup();
 
     // make context available globally for setupFiles.


### PR DESCRIPTION
Fixes #22.

## Problem

The current implementation uses `createRequire(import.meta.url)` to synchronously `require()` the Prisma client at `options.clientPath`:

```ts
const require = createRequire(import.meta.url);
const { PrismaClient } = require(options.clientPath);
```

This is incompatible with Prisma 7's `prisma-client` generator, which outputs plain TypeScript (ESM) files that Node's native CJS `require()` cannot load. Under Vitest, those TS files are transformed by Vite — but the plugin's `createRequire`-based `require()` bypasses Vite's loader entirely, so resolution fails with either `Cannot find module` (when pointed at an extensionless path) or `ERR_MODULE_NOT_FOUND` on transitive imports (when pointed at the `.ts` file).

## Fix

Switch to `await import(options.clientPath)`:

- Under Vitest, `clientPath` pointed at the generated `client.ts` (or `client.js`) is handled by Vite's transform pipeline, which resolves TypeScript/ESM transparently.
- Under plain Node, any ESM-compatible specifier works — package names (e.g. `@prisma/client`), `file://` URLs, or `.js`/`.mjs` paths.

Before dispatching the dynamic import, `clientPath` is normalized so that relative (`./foo`, `../foo`) and absolute filesystem paths are resolved against the consuming project's `process.cwd()` and converted to `file://` URLs. Bare module specifiers and pre-built `file://` URLs pass through unchanged. This means users can pass a natural project-relative path — `clientPath: "./src/generated/prisma/client.ts"` — without manually constructing a `file://` URL, and absolute paths work correctly on Windows (where ESM `import()` otherwise rejects bare drive paths).

`createContext` becomes `async`; the only caller (`environment.setup` in `src/index.ts`) is already async and just needs an `await`.

## Tested

- Unit tests (11 tests across `src/contest.test.ts` and `src/index.test.ts`) all pass with 100% coverage preserved. Added a regression test that passes an absolute `file://` URL as `clientPath` to cover the Prisma 7 path and the non-path-like branch of the resolver.
- Verified end-to-end against Prisma 7's `prisma-client` generator in a downstream project: 792 integration tests pass. With the new normalization, the config can be as simple as:

  ```ts
  // vitest.config.ts
  environmentOptions: {
    "prisma-postgres": {
      clientPath: "./src/generated/prisma/client.ts",
    },
  }
  ```

  A manually constructed `file://` URL via `pathToFileURL(path.resolve(...))` still works too.

  ```prisma
  generator client {
    provider            = "prisma-client"
    output              = "../src/generated/prisma"
    runtime             = "nodejs"
    moduleFormat        = "esm"
    importFileExtension = "ts"
  }
  ```

## Breaking change?

Technically yes — `createContext` now returns a `Promise`. No public users of `createContext` directly are documented in the README; consumers interact only through the Vitest environment, which is updated here. Happy to add a note to CHANGELOG if desired.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Context initialization is now asynchronous to support dynamic module loading and improve startup reliability.
* **Bug Fixes**
  * Improved handling of relative and absolute client module paths, including file:// URLs, for more predictable module resolution.
* **Tests**
  * Added coverage for absolute file:// client paths and full setup/teardown flow to prevent regressions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->