### PR TITLE
chore: migrate biome config to schema 2.3.10

### DIFF
--- a/biome.jsonc
+++ b/biome.jsonc
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://biomejs.dev/schemas/2.3.8/schema.json",
+  "$schema": "https://biomejs.dev/schemas/2.3.10/schema.json",
   "files": {
     "includes": ["**", "!!coverage", "!!dist"]
   },


### PR DESCRIPTION
## Summary

- Bump the `biome.jsonc` `$schema` from `2.3.8` to `2.3.10` to match the installed `@biomejs/biome` (`2.3.10`), removing the schema version mismatch reported by `biome`.

Config-only change; no source or behavior changes.